### PR TITLE
fix: Revert "style: Use `meltano-edk` in `pyproject.toml`"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ PyYAML = "^6.0.0"
 pydantic = "^1.9.0"
 typer = "^0.6.1"
 devtools = "^0.9.0"
-meltano-edk = {git = "https://github.com/meltano/edk.git", rev = "main"}
+"meltano.edk" = {git = "https://github.com/meltano/edk.git", rev = "main"}
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
Reverts meltano/airflow-ext#10

Closes #12 