### PR TITLE
fix: start_date may not be present in jobs

### DIFF
--- a/files_airflow_ext/orchestrate/meltano.py
+++ b/files_airflow_ext/orchestrate/meltano.py
@@ -124,12 +124,7 @@ def _meltano_job_generator(schedules):
         common_tags.append(f"job:{schedule['job']['name']}")
         interval = schedule["cron_interval"]
         args = DEFAULT_ARGS.copy()
-
-        if schedule["start_date"]:
-            args["start_date"] = schedule["start_date"]
-        else:
-            # Default to epoch; as it's not set to catch-up, so will only run once.
-            args["start_date"] = datetime(1970, 1, 1, 0, 0, 0)
+        args["start_date"] = schedule.get("start_date", datetime(1970, 1, 1, 0, 0, 0))
 
         with DAG(
             base_id,


### PR DESCRIPTION
closes #11 

same fix as https://github.com/meltano/files-airflow/pull/30