### PR TITLE
support schedule env vars

### DIFF
--- a/files_airflow_ext/orchestrate/meltano.py
+++ b/files_airflow_ext/orchestrate/meltano.py
@@ -151,6 +151,8 @@ def _meltano_job_generator(schedules):
                     task_id=task_id,
                     bash_command=f"cd {PROJECT_ROOT}; {MELTANO_BIN} run {run_args}",
                     dag=dag,
+                    env=schedule.get("env", {}),   # snag an env from the schedule
+                    append_env=True, # append , don't replace the inherited env
                 )
                 if previous_task:
                     task.set_upstream(previous_task)


### PR DESCRIPTION
The sibling issue to https://github.com/meltano/files-airflow/pull/36. If we merge that this should also be merged to be consistent across the legacy airflow orchestrator and new utility extension.