### PR TITLE
fix: Handle `start_date` for schedule that miss the value

### DIFF
--- a/files_airflow_ext/orchestrate/meltano.py
+++ b/files_airflow_ext/orchestrate/meltano.py
@@ -64,8 +64,7 @@ def _meltano_elt_generator(schedules: list) -> None:
             continue
 
         args = DEFAULT_ARGS.copy()
-        if schedule["start_date"]:
-            args["start_date"] = schedule["start_date"]
+        args["start_date"] = schedule.get("start_date", datetime(1970, 1, 1, 0, 0, 0))
 
         dag_id = f"meltano_{schedule['name']}"
 


### PR DESCRIPTION
Related:

- https://github.com/meltano/airflow-ext/pull/14
- https://github.com/meltano/meltano/issues/2484#issuecomment-2456020816