### PR TITLE
fix: airflow 3.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Apache Airflow 2.7+ is required, adjustments made for Airflow 3.x compatibility
     - name: webserver.web_server_port
       label: Webserver Port
       value: 8080
-      env: AIRFLOW__WEBSERVER__WEB_SERVER_PORT
+      env: AIRFLOW__API__PORT
+      description: |
+        The web and API server port, formerly set by AIRFLOW__WEBSERVER__WEB_SERVER_PORT in Airflow 2.x. If this variable
+        remains unset with Airflow 3.x, configuration generation may fail as the airflow.cfg file catches debug logs through
+        'stdout' upon creation by 'airflow config list --defaults'.
     - name: logging.base_log_folder
       label: Base Log Folder
       value: $MELTANO_PROJECT_ROOT/.meltano/utilities/airflow/logs

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ meltano invoke airflow users create -u admin@localhost -p password --role Admin 
 
 # start the scheduler, backgrounding the process
 meltano invoke airflow scheduler &
+# start the triggerer, backgrounding the process
+meltano invoke airflow triggerer &
+# start the dag processor, backgrounding the process
+meltano invoke airflow dag-processor &
 # start the webserver, keeping it in the foreground
-meltano invoke airflow webserver
+meltano invoke airflow api-server
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Meltano Airflow utility extension
 
-Apache Airflow 2.7+ is required.
+Apache Airflow 2.7+ is required, adjustments made for Airflow 3.x compatibility
 
 ## Example meltano.yml entry
 
@@ -10,8 +10,12 @@ Apache Airflow 2.7+ is required.
   utilities:
   - name: airflow
     namespace: airflow
-    pip_url: git+https://github.com/meltano/airflow-ext.git@main apache-airflow==2.3.3
-      --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.3.3/constraints-no-providers-3.8.txt
+    pip_url: >
+      git+https://github.com/meltano/edk.git@main
+      git+https://github.com/monomeric/airflow-ext.git@main
+      apache-airflow[postgres]==3.2.0
+      apache-airflow-providers-fab
+      --constraint https://raw.githubusercontent.com/apache/airflow/constraints-3.2.0/constraints-no-providers-${MELTANO__PYTHON_VERSION}.txt
     executable: airflow_invoker
     commands:
       describe:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Apache Airflow 2.7+ is required, adjustments made for Airflow 3.x compatibility
     pip_url: >
       git+https://github.com/meltano/edk.git@main
       git+https://github.com/monomeric/airflow-ext.git@main
-      apache-airflow[postgres]==3.2.0
-      apache-airflow-providers-fab
+      apache-airflow==3.2.0
       --constraint https://raw.githubusercontent.com/apache/airflow/constraints-3.2.0/constraints-no-providers-${MELTANO__PYTHON_VERSION}.txt
     executable: airflow_invoker
     commands:

--- a/airflow_ext/wrapper.py
+++ b/airflow_ext/wrapper.py
@@ -116,13 +116,17 @@ class Airflow(ExtensionBase):
         try:
             proc = self.airflow_invoker.run(
                 "config",
-                "generate",
-                "--output-file",
-                self.airflow_cfg_path,
+                "list",
+                "--defaults",
+                stdout=subprocess.PIPE,
             )
         except subprocess.CalledProcessError as err:
             log_subprocess_error("airflow config generate", err, "initial airflow invocation failed")
             sys.exit(err.returncode)
+
+        if proc.stdout:
+            with self.airflow_cfg_path.open("w") as f:
+                f.write(proc.stdout)
 
     def _initdb(self) -> None:
         """Initialize the airflow metadata database."""

--- a/airflow_ext/wrapper.py
+++ b/airflow_ext/wrapper.py
@@ -130,8 +130,25 @@ class Airflow(ExtensionBase):
 
     def _initdb(self) -> None:
         """Initialize the airflow metadata database."""
+        
+        # Airflow version 2 uses "db init" while version 3 expects "db migrate"
         try:
-            self.airflow_invoker.run("db", "migrate")
+            version = self.airflow_invoker.run("version")
         except subprocess.CalledProcessError as err:
-            log_subprocess_error("airflow db migrate", err, "airflow db migrate failed")
+            log_subprocess_error("airflow version", err, "airflow version failed")
             sys.exit(err.returncode)
+        
+        if version.startswith("2."):
+            try:
+                self.airflow_invoker.run("db", "init")
+            except subprocess.CalledProcessError as err:
+                log_subprocess_error("airflow db init", err, "airflow db init failed")
+                sys.exit(err.returncode)
+        elif version.startswith("3.")::
+            try:
+                self.airflow_invoker.run("db", "migrate")
+            except subprocess.CalledProcessError as err:
+                log_subprocess_error("airflow db migrate", err, "airflow db migrate failed")
+                sys.exit(err.returncode)
+        else:
+            log.warning("unhandled airflow version for db initialization")

--- a/airflow_ext/wrapper.py
+++ b/airflow_ext/wrapper.py
@@ -118,16 +118,11 @@ class Airflow(ExtensionBase):
                 "config",
                 "generate",
                 "--output-file",
-                str(self.airflow_home / "airflow.cfg"),
-                stdout=False,
+                self.airflow_cfg_path,
             )
         except subprocess.CalledProcessError as err:
             log_subprocess_error("airflow config generate", err, "initial airflow invocation failed")
             sys.exit(err.returncode)
-
-        if proc.stdout:
-            with self.airflow_cfg_path.open("w") as f:
-                f.write(proc.stdout)
 
     def _initdb(self) -> None:
         """Initialize the airflow metadata database."""

--- a/airflow_ext/wrapper.py
+++ b/airflow_ext/wrapper.py
@@ -131,7 +131,7 @@ class Airflow(ExtensionBase):
     def _initdb(self) -> None:
         """Initialize the airflow metadata database."""
         
-        # Airflow version 2 uses "db init" while version 3 expects "db migrate"
+        # Airflow version 2 accepts "db init" while version 3 expects "db migrate"
         try:
             version = self.airflow_invoker.run("version")
         except subprocess.CalledProcessError as err:
@@ -144,7 +144,7 @@ class Airflow(ExtensionBase):
             except subprocess.CalledProcessError as err:
                 log_subprocess_error("airflow db init", err, "airflow db init failed")
                 sys.exit(err.returncode)
-        elif version.startswith("3.")::
+        elif version.startswith("3."):
             try:
                 self.airflow_invoker.run("db", "migrate")
             except subprocess.CalledProcessError as err:

--- a/airflow_ext/wrapper.py
+++ b/airflow_ext/wrapper.py
@@ -131,7 +131,7 @@ class Airflow(ExtensionBase):
     def _initdb(self) -> None:
         """Initialize the airflow metadata database."""
         try:
-            self.airflow_invoker.run("db", "init")
+            self.airflow_invoker.run("db", "migrate")
         except subprocess.CalledProcessError as err:
-            log_subprocess_error("airflow db init", err, "airflow db init failed")
+            log_subprocess_error("airflow db migrate", err, "airflow db migrate failed")
             sys.exit(err.returncode)

--- a/airflow_ext/wrapper.py
+++ b/airflow_ext/wrapper.py
@@ -130,14 +130,13 @@ class Airflow(ExtensionBase):
 
     def _initdb(self) -> None:
         """Initialize the airflow metadata database."""
-        
         # Airflow version 2 accepts "db init" while version 3 expects "db migrate"
         try:
             proc = self.airflow_invoker.run("version", stdout=subprocess.PIPE)
         except subprocess.CalledProcessError as err:
             log_subprocess_error("airflow version", err, "airflow version failed")
             sys.exit(err.returncode)
-        
+
         if proc.stdout.startswith("2."):
             try:
                 self.airflow_invoker.run("db", "init")

--- a/airflow_ext/wrapper.py
+++ b/airflow_ext/wrapper.py
@@ -116,9 +116,10 @@ class Airflow(ExtensionBase):
         try:
             proc = self.airflow_invoker.run(
                 "config",
-                "list",
-                "--defaults",
-                stdout=subprocess.PIPE,
+                "generate",
+                "--output-file",
+                str(self.airflow_home / "airflow.cfg"),
+                stdout=False,
             )
         except subprocess.CalledProcessError as err:
             log_subprocess_error("airflow config generate", err, "initial airflow invocation failed")

--- a/airflow_ext/wrapper.py
+++ b/airflow_ext/wrapper.py
@@ -133,22 +133,22 @@ class Airflow(ExtensionBase):
         
         # Airflow version 2 accepts "db init" while version 3 expects "db migrate"
         try:
-            version = self.airflow_invoker.run("version")
+            proc = self.airflow_invoker.run("version", stdout=subprocess.PIPE)
         except subprocess.CalledProcessError as err:
             log_subprocess_error("airflow version", err, "airflow version failed")
             sys.exit(err.returncode)
         
-        if version.startswith("2."):
+        if proc.stdout.startswith("2."):
             try:
                 self.airflow_invoker.run("db", "init")
             except subprocess.CalledProcessError as err:
                 log_subprocess_error("airflow db init", err, "airflow db init failed")
                 sys.exit(err.returncode)
-        elif version.startswith("3."):
+        elif proc.stdout.startswith("3."):
             try:
                 self.airflow_invoker.run("db", "migrate")
             except subprocess.CalledProcessError as err:
                 log_subprocess_error("airflow db migrate", err, "airflow db migrate failed")
                 sys.exit(err.returncode)
         else:
-            log.warning("unhandled airflow version for db initialization")
+            log.error("unhandled airflow version for database initialization")

--- a/poetry.lock
+++ b/poetry.lock
@@ -4102,7 +4102,7 @@ files = [
 devtools = ">=0.9.0,<1"
 pydantic = ">=2,<3"
 PyYAML = ">=6,<7"
-structlog = ">=21,<=25"
+structlog = ">=21,<26"
 
 [package.extras]
 docs = ["furo (>=2022.12.7,<2025.0.0)", "myst-parser (>=0.17.2,<3.1.0)", "sphinx (>=4.5,<9.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.3.1,<0.6.0)"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -4087,7 +4087,7 @@ files = [
 ]
 
 [[package]]
-name = "meltano-edk"
+name = "meltano.edk"
 version = "0.5.0"
 description = "A framework for building Meltano extensions"
 optional = false

--- a/poetry.lock
+++ b/poetry.lock
@@ -4102,7 +4102,7 @@ files = [
 devtools = ">=0.9.0,<1"
 pydantic = ">=2,<3"
 PyYAML = ">=6,<7"
-structlog = ">=21,<25"
+structlog = ">=21,<=25"
 
 [package.extras]
 docs = ["furo (>=2022.12.7,<2025.0.0)", "myst-parser (>=0.17.2,<3.1.0)", "sphinx (>=4.5,<9.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.3.1,<0.6.0)"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -4088,14 +4088,14 @@ files = [
 
 [[package]]
 name = "meltano-edk"
-version = "0.4.4"
+version = "0.5.0"
 description = "A framework for building Meltano extensions"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "meltano_edk-0.4.4-py3-none-any.whl", hash = "sha256:ca0db2054ca6831ada0ba764445d3e776c29b2cc9c04489994b38399e1ac1de4"},
-    {file = "meltano_edk-0.4.4.tar.gz", hash = "sha256:ab6a50510bb616a8b90007f0af88f186aaae9ee48f79737cc54812da4b4836cc"},
+    {file = "meltano_edk-0.5.0-py3-none-any.whl", hash = "sha256:fbb45da002265e2bf584e2002af25f33a9744c1215ad417a744ff146d42e75a8"},
+    {file = "meltano_edk-0.5.0.tar.gz", hash = "sha256:daa76ffa094cc278044f660fb5eccb5a74960e83f0ba7fc94dc5f987b7db3dc9"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ include = [
 python = ">=3.8,<4"
 structlog = ">=20.1.0"
 typer = ">=0.19.0"
-"meltano.edk" = "~=0.4.4"
+"meltano.edk" = "~=0.5.0"
 
 [tool.poetry.group.dev.dependencies]
 apache-airflow = ">=2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ include = [
 python = ">=3.8,<4"
 structlog = ">=20.1.0"
 typer = ">=0.19.0"
-"meltano.edk" = "~=0.5.0"
+"meltano.edk" = "~=0.6.0"
 
 [tool.poetry.group.dev.dependencies]
 apache-airflow = ">=2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
 structlog = ">=20.1.0"
-typer = "^0.20.1"
+typer = "^0.20.0"
 "meltano.edk" = "~=0.4.4"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
 structlog = ">=20.1.0"
-typer = "^0.20.0"
+typer = ">=0.19.0"
 "meltano.edk" = "~=0.4.4"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This allows Airflow 3.x to be installed along and controlled by the extension, addressing #155. Backward compatibility with 2.x to be confirmed.

Tested versions:
- 2.10.5: installs fine, no thorough runtime tests
- 3.1.5: installs fine, runtime ok
- 3.2.0: installs fine, runtime ok